### PR TITLE
Optional toggles for distance grow and texture colors

### DIFF
--- a/Shaders/KF_AvatarTextShader.shader
+++ b/Shaders/KF_AvatarTextShader.shader
@@ -178,7 +178,6 @@ Shader "Unlit/KF_VRChatAvatarTextShader"
 		}
 
 		LOD 100
-		Blend SrcAlpha OneMinusSrcAlpha
 		Cull [_Culling]
 		ZWrite Off
 		AlphaToMask On


### PR DESCRIPTION
Hello! I've added some additional optional toggles to the text shader, that prevented some other projects to use the newer version of the shader.
Like [TTS-Voice-Wizard's](https://github.com/VRCWizard/TTS-Voice-Wizard) and [VRCTextboxSTT's](https://github.com/I5UCC/VRCTextboxSTT) emote feature, as currently colors are being displayed weirdly for them:
![Untitled-2](https://user-images.githubusercontent.com/43730681/217396625-0c692c43-8dc0-477f-a29f-66a4c7195bf7.png)

And [Billboard](https://github.com/Frosty704/Billboard), as it uses additional meshes around the Text. Growing with distance leads to unwanted behaviour here and is therefore using an older version of the shader:
![Billboard](https://user-images.githubusercontent.com/36753686/216971730-91ce1221-bc68-4af0-b51b-da25ce69a4ac.gif)

In particular two Properties have been added:
- _ColorsDisabled: Toggles the use of _MainColor and _ShadowColor to allow for displaying something else other then just text (Like emotes)
- _GrowEnabled: Toggles the "Growing with distance" feature on the shader.

Both properties default values are set not to interfere with existing setups. _GrowEnabled set to True and _ColorsDisabled set to False